### PR TITLE
Fix Liquid Warnings in atom.xml and resources.md

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -24,7 +24,7 @@ title : Atom Feed
     <link href="{{ site.production_url }}{{ post.url }}"/>
     <updated>{{ post.date | date_to_xmlschema }}</updated>
     <id>{{ post.url | remove: '/' }}</id>
-	{% capture summary %}{% assign tags = post.tags | join: "," %}{% assign addrs = post.addrs | join: "," %}{{ post.categories | join: "," | append: "," | append: post.keywords | append:"," | append:post.album | append:"," | append: tags | append: ',' | append: addrs | strip_html | xml_escape | downcase | split:"," | sort | uniq | join:"," }}{% endcapture %}{% if summary.size != 0 %}<summary>{{summary | prepend:"pLACeHoldER," | replace: ",,,":"," | replace: ",,":"," | remove:'pLACeHoldER,' }}</summary>{%endif%}
+	{% capture summary %}{% assign tags = post.tags | join: "," %}{% assign addrs = post.addrs | join: "," %}{{ post.categories | join: "," | append: "," | append: post.keywords | append:"," | append:post.album | append:"," | append: tags | append: ',' | append: addrs | strip_html | xml_escape | downcase | split:"," | sort | uniq | join:"," }}{% endcapture %}{% if summary.size != 0 %}<summary>{{summary | prepend:"pLACeHoldER," | replace: ",,,", "," | replace: ",,", "," | remove:'pLACeHoldER,' }}</summary>{%endif%}
     {% capture content %}{{ post.content | strip_html | replace: nl0, ' ' | replace: '    ', ' ' | replace: '   ', ' ' | replace: '  ', ' ' | strip | truncate:200 | xml_escape }}{% endcapture %}{% if content.size != 0 %}<content type="html">{{content}}</content>{% endif %}
   </entry>
 {% endfor %}
@@ -33,7 +33,7 @@ title : Atom Feed
     <link href="{{ site.production_url }}{{ page.url }}"/>
     <updated>{{ site.time | date_to_xmlschema }}</updated>
     <id>{{ page.url | remove: site.production_url | remove: '/' }}</id>
-	{% capture summary %}{% assign tags = page.tags | join: "," %}{% assign addrs = post.addrs | join: "," %}{{ page.categories | join: "," | append: "," | append: page.keywords | append:"," | append:post.album | append:"," | append: tags | append: ',' | append: addrs | strip_html | xml_escape | downcase | split:"," | sort | uniq | join:"," }}{% endcapture %}{% if summary.size != 0 %}<summary>{{summary | prepend:"pLACeHoldER," | replace: ",,,":"," | replace: ",,":"," | remove:'pLACeHoldER,' }}</summary>{%endif%}
+	{% capture summary %}{% assign tags = page.tags | join: "," %}{% assign addrs = post.addrs | join: "," %}{{ page.categories | join: "," | append: "," | append: page.keywords | append:"," | append:post.album | append:"," | append: tags | append: ',' | append: addrs | strip_html | xml_escape | downcase | split:"," | sort | uniq | join:"," }}{% endcapture %}{% if summary.size != 0 %}<summary>{{summary | prepend:"pLACeHoldER," | replace: ",,,", "," | replace: ",,", "," | remove:'pLACeHoldER,' }}</summary>{%endif%}
     {% capture content %}{{ page.content | strip_html | replace: nl0, ' ' | replace: '    ', ' ' | replace: '   ', ' ' | replace: '  ', ' ' | strip | truncate:200 | xml_escape }}{% endcapture %}{% if content.size != 0 %}<content type="html">{{content}}</content>{% endif %}
   </entry>
 {% endfor %}

--- a/google076a81ad1e2afd53.html
+++ b/google076a81ad1e2afd53.html
@@ -1,0 +1,1 @@
+google-site-verification: google076a81ad1e2afd53.html

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -39,11 +39,11 @@ order: 100
      {% endif %}
      {% for article in articles %}
        {% if condition %}
-         {% if article[{{condition}}] == {{value}} %}
+         {% if article[condition] == value %}
            {% assign size = 1 %}
            {% break %}
          {% endif %}
-         {% if condition == 'path' and article[{{condition}}] contains {{value}} %}
+         {% if condition == 'path' and article[condition] contains value %}
            {% assign size = 1 %}
            {% break %}
          {% endif %}
@@ -84,11 +84,11 @@ order: 100
 
         {% if condition %}
           {% if condition != 'path' %}
-            {% if article[{{condition}}] != {{value}} %}
+            {% if article[condition] != value %}
               {% continue %}
             {% endif %}
           {% else %}
-            {% unless article[{{condition}}] contains {{value}} %}
+            {% unless article[condition] contains value %}
               {% continue %}
             {%endunless%}
           {% endif %}


### PR DESCRIPTION
"""
Liquid Warning: Liquid syntax error (line 23): Expected end_of_string
but found colon in "{{summary | prepend:"pLACeHoldER," | replace:
",,,":"," | replace: ",,":"," | remove:'pLACeHoldER,' }}" in atom.xml
"""

For replace filter, use comma, not colon, to seperate two parameters.
See:
https://help.shopify.com/themes/liquid/filters/string-filters#replace

"""
Liquid Warning: Liquid syntax error (line 66): Unexpected character { in
"article[{{condition}}] != {{value}}" in pages/resources.md
"""
Neither '{{' nor '}}' are needed inside {% ... %}
See:
http://stackoverflow.com/questions/39688902/liquid-warning-liquid-syntax-error-unexpected-character-when-i-jekyll-serve