### PR TITLE
add license template

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -154,6 +154,7 @@ task :post do
     post.puts "#{tagline}"
     post.puts "#{album}"
     post.puts "#{group}"
+    post.puts 'license: "cc-by-sa-4.0"'
     post.puts "#{permalink}"
     post.puts 'description: " 文章摘要 "'
     post.puts 'plugin: mermaid'


### PR DESCRIPTION
add license template when using tools/post.
we can make it configurable, but if we are not going to use other licenses, `cc-by-sa-4.0` will be enough. 

Signed-off-by: tacinight <tacingiht@gmail.com>